### PR TITLE
Handle split TOC number entries

### DIFF
--- a/tests/test_split_sections.py
+++ b/tests/test_split_sections.py
@@ -1,0 +1,35 @@
+"""Tests for the table-of-contents splitting helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from split_sections import _extract_toc_entries
+
+
+def test_extract_toc_entries_combines_split_numbering_lines() -> None:
+    """Table-of-contents numbers split across lines are reconstructed."""
+
+    pages = [
+        [
+            "目录",
+            "1 概述 .......... 1",
+            "1.1",
+            " 告警监控是什么 .......... 2",
+            "1.2",
+            " 告警监控简介",
+            " 发展历史 .......... 3",
+        ]
+    ]
+
+    entries, last_position = _extract_toc_entries(pages)
+
+    assert entries == [
+        "1 概述",
+        "1.1 告警监控是什么",
+        "1.2 告警监控简介 发展历史",
+    ]
+    assert last_position == (0, 6)


### PR DESCRIPTION
## Summary
- recognise numbering-only TOC lines and buffer them until the dotted leader/page number appears
- combine buffered segments before cleaning so split table-of-contents entries retain their numbering
- add pytest coverage for TOC pages where numbers and titles are split across lines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6af776cc83248267d12bb7e5555f